### PR TITLE
Stops DishViewModel being called again on every recomposition and configuration change

### DIFF
--- a/app/src/main/java/com/example/disher/category/viewmodel/DishViewModel.kt
+++ b/app/src/main/java/com/example/disher/category/viewmodel/DishViewModel.kt
@@ -3,26 +3,32 @@ package com.example.disher.category.viewmodel
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.State
 import androidx.compose.runtime.mutableStateOf
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.disher.category.model.Dish
-import com.example.disher.category.repository.DishRepository
 import com.example.disher.category.usecase.IDishesUseCase
+import com.example.disher.navigation.Screen
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class DishViewModel @Inject constructor(val useCase: IDishesUseCase) : ViewModel() {
+class DishViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    val useCase: IDishesUseCase
+) : ViewModel() {
 
     private val _listOfDish: MutableState<List<Dish>> = mutableStateOf(emptyList())
     val listOfDish: State<List<Dish>> = _listOfDish
 
+    init {
+        savedStateHandle.get<String>(Screen.Dishes.CATEGORY)?.let {
+            getAllDish(it)
+        }
+    }
 
-
-    fun getAllDish(selectedCategory: String){
+    private fun getAllDish(selectedCategory: String){
         viewModelScope.launch {
             val dishList = useCase(selectedCategory)
             _listOfDish.value = dishList.meals

--- a/app/src/main/java/com/example/disher/dishes/DishesScreen.kt
+++ b/app/src/main/java/com/example/disher/dishes/DishesScreen.kt
@@ -9,12 +9,8 @@ import com.example.disher.category.viewmodel.DishViewModel
 private const val TAG = "DishesScreen"
 
 @Composable
-fun DishesScreen(
-    selectedCategory: String,
-    viewModel: DishViewModel = hiltViewModel()
-) {
+fun DishesScreen(viewModel: DishViewModel = hiltViewModel()) {
 
-    viewModel.getAllDish(selectedCategory = selectedCategory)
     Text(text = viewModel.listOfDish.value.toString())
 
 

--- a/app/src/main/java/com/example/disher/navigation/DisherNavigation.kt
+++ b/app/src/main/java/com/example/disher/navigation/DisherNavigation.kt
@@ -26,12 +26,10 @@ fun DisherNavigation() {
         }
 
         composable(
-            route = "${Dishes.route}/{selectedCategory}",
-            arguments = listOf(navArgument("selectedCategory") { type = NavType.StringType })
-        ) { navBackStackEntry ->
-            navBackStackEntry.arguments?.getString("selectedCategory")?.let { category ->
-                DishesScreen(selectedCategory = category)
-            }
+            route = "${Dishes.route}/{${Dishes.CATEGORY}}",
+            arguments = listOf(navArgument(Dishes.CATEGORY) { type = NavType.StringType })
+        ) {
+            DishesScreen()
         }
 
         composable(route = DishDetail.route) {

--- a/app/src/main/java/com/example/disher/navigation/Screen.kt
+++ b/app/src/main/java/com/example/disher/navigation/Screen.kt
@@ -2,6 +2,8 @@ package com.example.disher.navigation
 
 sealed class Screen(val route: String) {
     object Category: Screen(route = "category")
-    object Dishes: Screen(route = "dishes")
+    object Dishes: Screen(route = "dishes") {
+        const val CATEGORY = "category"
+    }
     object DishDetail: Screen(route = "dish_detail")
 }


### PR DESCRIPTION
`DishViewModel.getAllDish` was being called on every recomposition and configuration change (i.e. screen orientation change).
`LaunchedEffect` solves the recomposition problem but not a configuration change. `SavedStateHandle` helps to handle both cases.